### PR TITLE
Add support for KIP-98 headers

### DIFF
--- a/confluent_kafka/src/Consumer.c
+++ b/confluent_kafka/src/Consumer.c
@@ -884,7 +884,7 @@ static PyObject *Consumer_poll (Handle *self, PyObject *args,
         if (!rkm)
                 Py_RETURN_NONE;
 
-        msgobj = Message_new0(self, rkm);
+        msgobj = Message_new0(self, rkm, true);
         rd_kafka_message_destroy(rkm);
 
         return msgobj;
@@ -945,7 +945,7 @@ static PyObject *Consumer_consume (Handle *self, PyObject *args,
         msglist = PyList_New(n);
 
         for (i = 0; i < n; i++) {
-                PyObject *msgobj = Message_new0(self, rkmessages[i]);
+                PyObject *msgobj = Message_new0(self, rkmessages[i], true);
                 PyList_SET_ITEM(msglist, i, msgobj);
                 rd_kafka_message_destroy(rkmessages[i]);
         }

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -271,12 +271,16 @@ parse_dict_headers (PyObject *headers) {
 			rd_kafka_headers_destroy(hdrs);
 			return NULL;
 		}
-		if (cfl_PyBin(_AsStringAndSize(value, &valbuf, &len)) < 0) {
-			rd_kafka_headers_destroy(hdrs);
-			return NULL;
+		if (value == Py_None) {
+			rd_kafka_header_add(hdrs, keybuf, -1, NULL, 0);
+		} else {
+			if (cfl_PyBin(_AsStringAndSize(value, &valbuf, &len)) < 0) {
+				rd_kafka_headers_destroy(hdrs);
+				return NULL;
+			}
+			rd_kafka_header_add(hdrs, keybuf, -1, valbuf, (size_t)len);
+			Py_XDECREF(tmpstr);
 		}
-		rd_kafka_header_add(hdrs, keybuf, -1, valbuf, (size_t)len);
-		Py_XDECREF(tmpstr);
 	}
 	return hdrs;
 }
@@ -306,12 +310,16 @@ parse_seq_headers (PyObject *headers) {
 			PyErr_Format(PyExc_TypeError, "Header keys must be strings.");
 			goto err;
 		}
-		if (cfl_PyBin(_AsStringAndSize(value, &valbuf, &len)) < 0)
-			goto err;
-		rd_kafka_header_add(hdrs, keybuf, -1, valbuf, (size_t)len);
+		if (value == Py_None) {
+			rd_kafka_header_add(hdrs, keybuf, -1, NULL, 0);
+		} else {
+			if (cfl_PyBin(_AsStringAndSize(value, &valbuf, &len)) < 0)
+				goto err;
+			rd_kafka_header_add(hdrs, keybuf, -1, valbuf, (size_t)len);
+			Py_XDECREF(tmpstr);
+		}
 		Py_DECREF(key);
 		Py_DECREF(value);
-		Py_XDECREF(tmpstr);
 	}
 	Py_DECREF(fasthdrs);
 	return hdrs;

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -252,13 +252,87 @@ int32_t Producer_partitioner_cb (const rd_kafka_topic_t *rkt,
 }
 
 
+#if HAVE_HEADERS
+static rd_kafka_headers_t *
+parse_dict_headers (PyObject *headers) {
+	Py_ssize_t pos = 0;
+	PyObject *key, *value, *tmpstr;
+	const char *keybuf;
+	char *valbuf;
+	Py_ssize_t len;
+	rd_kafka_headers_t *hdrs;
+
+	len = PyDict_Size(headers);
+	hdrs = rd_kafka_headers_new((size_t)len);
+	while (PyDict_Next(headers, &pos, &key, &value)) {
+		if (!(keybuf = cfl_PyUnistr_AsUTF8(key, &tmpstr))) {
+			PyErr_Format(PyExc_TypeError, "Header keys must be strings.");
+			Py_XDECREF(tmpstr);
+			rd_kafka_headers_destroy(hdrs);
+			return NULL;
+		}
+		if (cfl_PyBin(_AsStringAndSize(value, &valbuf, &len)) < 0) {
+			rd_kafka_headers_destroy(hdrs);
+			return NULL;
+		}
+		rd_kafka_header_add(hdrs, keybuf, -1, valbuf, (size_t)len);
+		Py_XDECREF(tmpstr);
+	}
+	return hdrs;
+}
+
+
+static rd_kafka_headers_t *
+parse_seq_headers (PyObject *headers) {
+	PyObject *fasthdrs, **items, *item, *key, *value, *tmpstr;
+	const char *keybuf;
+	char *valbuf;
+	Py_ssize_t count, len;
+	rd_kafka_headers_t *hdrs;
+
+	fasthdrs = PySequence_Fast(headers, NULL);
+	count = PySequence_Fast_GET_SIZE(fasthdrs);
+	items = PySequence_Fast_ITEMS(fasthdrs);
+	hdrs = rd_kafka_headers_new((size_t)count);
+	for (Py_ssize_t i = 0; i < count; i++) {
+		item = items[i];
+		key = PySequence_GetItem(item, 0);
+		value = PySequence_GetItem(item, 1);
+		if (!key || !value) {
+			PyErr_Format(PyExc_ValueError, "Invalid header.");
+			goto err;
+		}
+		if (!(keybuf = cfl_PyUnistr_AsUTF8(key, &tmpstr))) {
+			PyErr_Format(PyExc_TypeError, "Header keys must be strings.");
+			goto err;
+		}
+		if (cfl_PyBin(_AsStringAndSize(value, &valbuf, &len)) < 0)
+			goto err;
+		rd_kafka_header_add(hdrs, keybuf, -1, valbuf, (size_t)len);
+		Py_DECREF(key);
+		Py_DECREF(value);
+		Py_XDECREF(tmpstr);
+	}
+	Py_DECREF(fasthdrs);
+	return hdrs;
+err:
+	Py_XDECREF(key);
+	Py_XDECREF(value);
+	Py_XDECREF(tmpstr);
+	Py_DECREF(fasthdrs);
+	rd_kafka_headers_destroy(hdrs);
+	return NULL;
+}
+#endif
+
+
 #if HAVE_PRODUCEV
 static rd_kafka_resp_err_t
 Producer_producev (Handle *self,
                    const char *topic, int32_t partition,
                    const void *value, size_t value_len,
                    const void *key, size_t key_len,
-                   void *opaque, int64_t timestamp) {
+                   void *opaque, int64_t timestamp, void *headers) {
 
         return rd_kafka_producev(self->rk,
                                  RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
@@ -269,6 +343,9 @@ Producer_producev (Handle *self,
                                                   (size_t)value_len),
                                  RD_KAFKA_V_TIMESTAMP(timestamp),
                                  RD_KAFKA_V_OPAQUE(opaque),
+#if HAVE_HEADERS
+                                 RD_KAFKA_V_HEADERS((rd_kafka_headers_t *)headers),
+#endif
                                  RD_KAFKA_V_END);
 }
 #else
@@ -303,8 +380,10 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
 	int value_len = 0, key_len = 0;
 	int partition = RD_KAFKA_PARTITION_UA;
 	PyObject *dr_cb = NULL, *dr_cb2 = NULL, *partitioner_cb = NULL;
-        long long timestamp = 0;
-        rd_kafka_resp_err_t err;
+	long long timestamp = 0;
+	PyObject *headers = NULL;
+	void *hdrs = NULL;
+	rd_kafka_resp_err_t err;
 	struct Producer_msgstate *msgstate;
 	static char *kws[] = { "topic",
 			       "value",
@@ -313,16 +392,17 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
 			       "callback",
 			       "on_delivery", /* Alias */
 			       "partitioner",
-                               "timestamp",
+			       "timestamp",
+			       "headers",
 			       NULL };
 
 	if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-					 "s|z#z#iOOOL"
+					 "s|z#z#iOOOLO"
                                          , kws,
 					 &topic, &value, &value_len,
 					 &key, &key_len, &partition,
 					 &dr_cb, &dr_cb2, &partitioner_cb,
-                                         &timestamp))
+                                         &timestamp, &headers))
 		return NULL;
 
 #if !HAVE_PRODUCEV
@@ -335,6 +415,32 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
                              rd_kafka_version(), RD_KAFKA_VERSION);
                 return NULL;
         }
+#endif
+#if !HAVE_HEADERS
+	if (headers) {
+		PyErr_Format(PyExc_NotImplementedError,
+			     "Message headers require "
+			     "confluent-kafka-python built for librdkafka "
+			     "version > v0.11.3 (librdkafka runtime 0x%x, "
+			     "buildtime 0x%x)",
+			     rd_kafka_version(), RD_KAFKA_VERSION);
+		return NULL;
+	}
+#else
+	if (headers) {
+		// Check for dict or tuple.
+		if (PyDict_Check(headers)) {
+			hdrs = (void *)parse_dict_headers(headers);
+		} else if (PySequence_Check(headers)) {
+			hdrs = (void *)parse_seq_headers(headers);
+		} else {
+			PyErr_Format(PyExc_ValueError, "Message headers must be a dict or iterable.");
+			return NULL;
+		}
+		if (!hdrs) {
+			return NULL;
+		}
+	}
 #endif
 
 	if (dr_cb2 && !dr_cb) /* Alias */
@@ -354,7 +460,7 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
         err = Producer_producev(self, topic, partition,
                                 value, value_len,
                                 key, key_len,
-                                msgstate, timestamp);
+                                msgstate, timestamp, hdrs);
 #else
         err = Producer_produce0(self, topic, partition,
                                 value, value_len,
@@ -375,6 +481,10 @@ static PyObject *Producer_produce (Handle *self, PyObject *args,
 					 "Unable to produce message: %s",
 					 rd_kafka_err2str(err));
 
+#if HAVE_HEADERS
+		if (hdrs)
+			rd_kafka_headers_destroy(hdrs);
+#endif
 		return NULL;
 	}
 
@@ -467,13 +577,16 @@ static PyMethodDef Producer_methods[] = {
 	  "  :param func on_delivery(err,msg): Delivery report callback to call "
 	  "(from :py:func:`poll()` or :py:func:`flush()`) on successful or "
 	  "failed delivery\n"
-          "  :param int timestamp: Message timestamp (CreateTime) in microseconds since epoch UTC (requires librdkafka >= v0.9.4, api.version.request=true, and broker >= 0.10.0.0). Default value is current time.\n"
+	  "  :param int timestamp: Message timestamp (CreateTime) in microseconds since epoch UTC (requires librdkafka >= v0.9.4, api.version.request=true, and broker >= 0.10.0.0). Default value is current time.\n"
+#if HAVE_HEADERS
+	  "  :param dict|iterable headers: string key and byte value headers in a dict or iterable of key, value tuples (requires librdkafka > v0.11.3 and broker >= 0.11.0.0).\n"
+#endif
 	  "\n"
 	  "  :rtype: None\n"
 	  "  :raises BufferError: if the internal producer message queue is "
 	  "full (``queue.buffering.max.messages`` exceeded)\n"
 	  "  :raises KafkaException: for other errors, see exception code\n"
-          "  :raises NotImplementedError: if timestamp is specified without underlying library support.\n"
+	  "  :raises NotImplementedError: if timestamp is specified without underlying library support.\n"
 	  "\n"
 	},
 

--- a/confluent_kafka/src/Producer.c
+++ b/confluent_kafka/src/Producer.c
@@ -156,7 +156,7 @@ static void dr_msg_cb (rd_kafka_t *rk, const rd_kafka_message_t *rkm,
         if (self->u.Producer.dr_only_error && !rkm->err)
                 goto done;
 
-	msgobj = Message_new0(self, rkm);
+	msgobj = Message_new0(self, (rd_kafka_message_t *)rkm, false);
 	
 	args = Py_BuildValue("(OO)",
 			     Message_error((Message *)msgobj, NULL),

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -530,10 +530,6 @@ static int Message_traverse (Message *self,
 		Py_VISIT(self->key);
 	if (self->error)
 		Py_VISIT(self->error);
-#if HAVE_HEADERS
-	if (self->headers)
-		Py_VISIT(self->headers);
-#endif
 	return 0;
 }
 

--- a/confluent_kafka/src/confluent_kafka.c
+++ b/confluent_kafka/src/confluent_kafka.c
@@ -907,7 +907,7 @@ PyObject *c_parts_to_py (const rd_kafka_topic_partition_list_t *c_parts) {
 
 	parts = PyList_New(c_parts->cnt);
 
-	for (i = 0 ; i < c_parts->cnt ; i++) {
+	for (i = 0 ; i < (size_t)c_parts->cnt ; i++) {
 		const rd_kafka_topic_partition_t *rktpar = &c_parts->elems[i];
 		PyList_SET_ITEM(parts, i,
 				TopicPartition_new0(
@@ -936,7 +936,7 @@ rd_kafka_topic_partition_list_t *py_to_c_parts (PyObject *plist) {
 
 	c_parts = rd_kafka_topic_partition_list_new((int)PyList_Size(plist));
 
-	for (i = 0 ; i < PyList_Size(plist) ; i++) {
+	for (i = 0 ; i < (size_t)PyList_Size(plist) ; i++) {
 		TopicPartition *tp = (TopicPartition *)
 			PyList_GetItem(plist, i);
 
@@ -1195,7 +1195,7 @@ static int producer_conf_set_special (Handle *self, rd_kafka_conf_t *conf,
 			}
 
 			 /* FIXME: Error out until GIL+rdkafka lock-ordering is fixed. */
-			if (1) {
+			if ((1)) {
 				cfl_PyErr_Format(
 					RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
 					"custom partitioner support not yet implemented");

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -17,6 +17,7 @@
 #include <Python.h>
 #include <structmember.h>
 #include <pythread.h>
+#include <stdbool.h>
 
 #include <librdkafka/rdkafka.h>
 
@@ -301,7 +302,7 @@ typedef struct {
 
 extern PyTypeObject MessageType;
 
-PyObject *Message_new0 (const Handle *handle, const rd_kafka_message_t *rkm);
+PyObject *Message_new0 (const Handle *handle, rd_kafka_message_t *rkm, bool detach_headers);
 PyObject *Message_error (Message *self, PyObject *ignore);
 
 

--- a/confluent_kafka/src/confluent_kafka.h
+++ b/confluent_kafka/src/confluent_kafka.h
@@ -57,6 +57,9 @@
 #define HAVE_PRODUCEV  1 /* rd_kafka_producev() */
 #endif
 
+#ifdef RD_KAFKA_V_HEADER
+#define HAVE_HEADERS  1 /* message headers */
+#endif
 
 
 /****************************************************************************
@@ -291,6 +294,9 @@ typedef struct {
 	int64_t offset;
 	int64_t timestamp;
 	rd_kafka_timestamp_type_t tstype;
+#if HAVE_HEADERS
+	rd_kafka_headers_t *headers;
+#endif
 } Message;
 
 extern PyTypeObject MessageType;


### PR DESCRIPTION
Add support for message headers.  This is functionally complete and current tests pass, but I still need to add new tests (and probably poke at it in Python 2.7).
This supports headers as either a dict of str keys and byte values or an iterable of str/byte iterables.  For producing messages, `produce()` will now take a `headers` keyword arg with headers passed as either type.  For receiving messages, the Message object now has a `headers()` method that returns the dict form and a `raw_headers()` method that preserves the KIP-98 requirements for ordering and duplicate values.
Usage looks like:
```Python
p = Producer(...)
p.produce("topic", "message 1", headers={"k1": b"v1"})
p.produce("topic", "message 2", headers=(("k1", b"v1"), ("k1", b"v2")))

c = Consumer(...)
c.subscribe(['topic'])
m = c.poll()
m.value()
# b'message 1'
m.headers()
# {'k1': b'v1'}
m.raw_headers
# (('k1', b'v1'),)
m = c.poll()
m.value()
# b'message 2'
m.headers()
# {'k1': b'v2'}
m.raw_headers()
(('k1', b'v1'), ('k1', b'v2'))
```
